### PR TITLE
Fix memory corruption crash when using libsndfile output formats

### DIFF
--- a/src/lame.c
+++ b/src/lame.c
@@ -201,14 +201,14 @@ encoder_funcs_t* init_lame( output_format_t* format, int channels, int bitrate )
   // Allocate memory for encoded audio
   mpeg_buffer = malloc( 1.25*SAMPLES_PER_FRAME + 7200 );
   if ( mpeg_buffer==NULL ) {
-    rotter_error( "Failed to allocate memery for encoded audio." );
+    rotter_error( "Failed to allocate memory for encoded audio." );
     return NULL;
   }
 
   // Allocate memory for callback functions
   funcs = calloc( 1, sizeof(encoder_funcs_t) );
   if ( funcs==NULL ) {
-    rotter_error( "Failed to allocate memery for encoder callback functions structure." );
+    rotter_error( "Failed to allocate memory for encoder callback functions structure." );
     return NULL;
   }
 

--- a/src/sndfile.c
+++ b/src/sndfile.c
@@ -187,7 +187,7 @@ encoder_funcs_t* init_sndfile( output_format_t* format, int channels, int bitrat
   // Allocate memory for callback functions
   funcs = calloc( 1, sizeof(encoder_funcs_t) );
   if ( funcs==NULL ) {
-    rotter_error( "Failed to allocate memery for encoder callback functions structure." );
+    rotter_error( "Failed to allocate memory for encoder callback functions structure." );
     return NULL;
   }
 

--- a/src/twolame.c
+++ b/src/twolame.c
@@ -141,14 +141,14 @@ encoder_funcs_t* init_twolame( output_format_t* format, int channels, int bitrat
   // Allocate memory for encoded audio
   mpeg_buffer = malloc( 1.25*TWOLAME_SAMPLES_PER_FRAME + 7200 );
   if ( mpeg_buffer==NULL ) {
-    rotter_error( "Failed to allocate memery for encoded audio." );
+    rotter_error( "Failed to allocate memory for encoded audio." );
     return NULL;
   }
 
   // Allocate memory for callback functions
   funcs = calloc( 1, sizeof(encoder_funcs_t) );
   if ( funcs==NULL ) {
-    rotter_error( "Failed to allocate memery for encoder callback functions structure." );
+    rotter_error( "Failed to allocate memory for encoder callback functions structure." );
     return NULL;
   }
 


### PR DESCRIPTION
This fixes a crash when using libsndfile output formats.

In write_sndfile(), interleaved_buffer was being allocated based on the number of samples, rather than the number of bytes needed to hold sample values. Multiplying by sizeof(jack_default_audio_sample_t) fixes this.

Hope this patch is of use and submitted in the right way. Please shout if you have any questions or need me to do anything else. And many thanks for creating rotter.

Below is the output of rotter, before the fix is applied:

$ ./src/rotter -j -v -f wav -L flat /home/nick/projects/rotter/test
[DEBUG]  Tue Jun  5 09:59:04 2012  Root directory: /home/nick/projects/rotter/test
[DEBUG]  Tue Jun  5 09:59:04 2012  User selected [wav] 'WAV (Microsoft 16 bit PCM)'.
[INFO]   Tue Jun  5 09:59:04 2012  JACK client registered as 'rotter'.
[DEBUG]  Tue Jun  5 09:59:04 2012  Size of the ring buffers is 2.00 seconds (384000 bytes).
[DEBUG]  Tue Jun  5 09:59:04 2012  Encoding using libsndfile version libsndfile-1.0.24.
[DEBUG]  Tue Jun  5 09:59:04 2012    Input: 48000 Hz, 2 channels
[DEBUG]  Tue Jun  5 09:59:04 2012    Output: WAV (Microsoft), Signed 16 bit PCM.
[DEBUG]  Tue Jun  5 09:59:04 2012  Sleep period is 21ms.
[INFO]   Tue Jun  5 09:59:04 2012  Opening new archive file for ringbuffer A: /home/nick/projects/rotter/test/2012-06-05-09.wav
[DEBUG]  Tue Jun  5 09:59:04 2012  Opening libsndfile output file: /home/nick/projects/rotter/test/2012-06-05-09.wav
**\* glibc detected **\* ./src/rotter: realloc(): invalid next size: 0x08395100 ***
======= Backtrace: =========
/lib/i386-linux-gnu/libc.so.6(+0x6ff22)[0x9eaf22]
/lib/i386-linux-gnu/libc.so.6(+0x7292f)[0x9ed92f]
/lib/i386-linux-gnu/libc.so.6(realloc+0xf7)[0x9eee17]
./src/rotter[0x804b6d4]
./src/rotter[0x804a4cf]
./src/rotter[0x8049bac]
/lib/i386-linux-gnu/libc.so.6(__libc_start_main+0xf3)[0x994113]
./src/rotter[0x8049d3d]
