### PR TITLE
Ignore -N option if accurate file layout is specified

### DIFF
--- a/src/rotter.c
+++ b/src/rotter.c
@@ -338,14 +338,9 @@ static char * time_to_filepath_accurate( struct tm *tm, unsigned int usec, const
 
 
   // Create the full file path
-  if (archive_name) {
-    snprintf( filepath, MAX_FILEPATH_LEN, "%s/%4.4d-%2.2d-%2.2d/%s-%4.4d-%2.2d-%2.2d-%2.2d.%s",
-          root_directory, tm->tm_year+1900, tm->tm_mon+1, tm->tm_mday, archive_name, tm->tm_year+1900, tm->tm_mon+1, tm->tm_mday, tm->tm_hour, suffix );
-  } else {
-    snprintf( filepath, MAX_FILEPATH_LEN, "%s/%4.4d-%2.2d-%2.2d/%4.4d-%2.2d-%2.2d-%2.2d-%2.2d-%2.2d-%2.2d.%s",
-          root_directory, tm->tm_year+1900, tm->tm_mon+1, tm->tm_mday, tm->tm_year+1900, tm->tm_mon+1, tm->tm_mday, tm->tm_hour,
-          tm->tm_min, tm->tm_sec, (int)(usec / 10000), suffix );
-  }
+  snprintf( filepath, MAX_FILEPATH_LEN, "%s/%4.4d-%2.2d-%2.2d/%4.4d-%2.2d-%2.2d-%2.2d-%2.2d-%2.2d-%2.2d.%s",
+        root_directory, tm->tm_year+1900, tm->tm_mon+1, tm->tm_mday, tm->tm_year+1900, tm->tm_mon+1, tm->tm_mday, tm->tm_hour,
+        tm->tm_min, tm->tm_sec, (int)(usec / 10000), suffix );
 
   return filepath;
 }


### PR DESCRIPTION
This patch ignores any archive name, (specified with the -N
command line option) if the 'accurate' file layout is in
use, fixing the current inconsistent and undocumented
behaviour.

Previously, if the accurate file layout was used in conjuction
with the -N option, rotter would not include the expected
minutes, seconds and hundredths of a second filename parts:

$ ./rotter -L accurate -N archive /tmp
[INFO]   Sun Jul  1 19:20:27 2012  JACK client registered as 'rotter'.
[INFO]   Sun Jul  1 19:20:27 2012  Opening new archive file for ringbuffer A: /tmp/2012-07-01/archive-2012-07-01-19.aiff

$ ./rotter -L accurate  /tmp
[INFO]   Sun Jul  1 19:20:50 2012  JACK client registered as 'rotter'.
[INFO]   Sun Jul  1 19:20:50 2012  Opening new archive file for ringbuffer A: /tmp/2012-07-01/2012-07-01-19-20-50-32.aiff
