### PR TITLE
Fix custom strftime-style format layout

### DIFF
--- a/src/rotter.c
+++ b/src/rotter.c
@@ -267,7 +267,7 @@ static int time_to_filepath_custom( struct tm *tm, char * file_layout, char* fil
   size_t len;
 
   // Copy root directory path and separator into new filepath
-  if (snprintf( filepath, MAX_FILEPATH_LEN, "%s/", root_directory ) <= 0);
+  if (snprintf( filepath, MAX_FILEPATH_LEN, "%s/", root_directory ) <= 0)
     return 1;
 
   // Get the length of the root directory


### PR DESCRIPTION
Starting rotter with a custom file layout (`-L "<strftime>"` ) leads to `Failed to build file path for layout` as the `snprintf()` check always returns `1`. This addresses #29.