### PR TITLE
Add missing argument to vprintf() in deletefiles_in_dir()

### DIFF
--- a/src/deletefiles.c
+++ b/src/deletefiles.c
@@ -122,7 +122,7 @@ static void deletefiles_in_dir( const char* dirpath, dev_t device, time_t timest
       delete_file( newpath, device, timestamp );
 
     } else {
-      rotter_error( "Warning: not a file or a directory: %s" );
+      rotter_error( "Warning: not a file or a directory: %s", newpath );
     }
     free( newpath );
 


### PR DESCRIPTION
If `dp->d_type` is not  `DT_DIR` or `DT_REG` within `deletefiles_in_dir()` the following error message will be printed: `"Warning: not a file or a directory: %s"`. However, `%s` will never be substituted, as the argument to the underlying `vprintf()` call is missing.

This PR fixes the `%s` substitution by passing the value of  `newpath`.